### PR TITLE
Record FE-41's independent release-candidate verification

### DIFF
--- a/artifacts/backlog/README.md
+++ b/artifacts/backlog/README.md
@@ -5,10 +5,10 @@
 Work on this project classified with the Extended Agile Hierarchy. Every item is a file in
 [`items/`](./items/); its YAML frontmatter is the source of truth and this page is derived from it.
 
-**39 of 48 leaf items complete — 81%**
+**39 of 49 leaf items complete — 80%**
 
 ```
-████████████████████████████████░░░░░░░░  81%
+████████████████████████████████░░░░░░░░  80%
 ```
 
 ## Status
@@ -16,11 +16,12 @@ Work on this project classified with the Extended Agile Hierarchy. Every item is
 | Status | Items |
 | --- | ---: |
 | ○ Not started | 1 |
-| ◑ In progress | 5 |
-| ● Complete | 60 |
+| ◑ In progress | 6 |
+| ◕ In review | 2 |
+| ● Complete | 59 |
 | ◌ Deferred | 8 |
 | — Cancelled | 6 |
-| **Total** | **80** |
+| **Total** | **82** |
 
 ## The hierarchy
 
@@ -29,22 +30,25 @@ Work on this project classified with the Extended Agile Hierarchy. Every item is
 | Theme | `TH-` | 1 | Which enduring area of value is this? |
 | Initiative | `IN-` | 4 | What outcome are we pursuing there? |
 | Epic | `EP-` | 11 | What large body of work delivers it? |
-| Feature | `FE-` | 40 | What shippable slice of that epic? |
-| Story | `ST-` | 24 | What user-visible change, roughly one PR? |
+| Feature | `FE-` | 41 | What shippable slice of that epic? |
+| Story | `ST-` | 25 | What user-visible change, roughly one PR? |
 | Task | `TA-` | 0 | What technical step inside a story? |
 
 ## Progress by theme
 
 | Theme | Progress | Done | Remaining |
 | --- | --- | ---: | ---: |
-| [TH-01 Assurance that does not manufacture certainty](./items/TH-01.md) | `███████████░░░` 81% | 39 | 9 |
+| [TH-01 Assurance that does not manufacture certainty](./items/TH-01.md) | `███████████░░░` 80% | 39 | 10 |
 
 ## In flight
 
+- ◑ [EP-07](./items/EP-07.md) — Tier 2 — false assurance
 - ◑ [EP-08](./items/EP-08.md) — Tier 3 — semantic inconsistency and representation
 - ◑ [EP-09](./items/EP-09.md) — Tier 4 — authoring and ergonomics
+- ◕ [FE-41](./items/FE-41.md) — NOT_EVALUATED must never carry a numeric compliance score
 - ◑ [IN-03](./items/IN-03.md) — Fix what the field trials falsified
 - ◑ [IN-04](./items/IN-04.md) — This repository's own verification is executed, not asserted
+- ◕ [ST-25](./items/ST-25.md) — Null the score on NOT_EVALUATED, and pin both routes to it
 - ◑ [TH-01](./items/TH-01.md) — Assurance that does not manufacture certainty
 
 ## Ready to pick up
@@ -53,7 +57,7 @@ _Nothing marked ready._
 
 ## Everything
 
-- ◑ **[TH-01](./items/TH-01.md)** Assurance that does not manufacture certainty _(39/48)_
+- ◑ **[TH-01](./items/TH-01.md)** Assurance that does not manufacture certainty _(39/49)_
   - ● **[IN-01](./items/IN-01.md)** A working policy-as-code pack for mathematical research _(9/9)_
     - ● **[EP-01](./items/EP-01.md)** The v1.0.0 framework _(6/6)_
       - ● **[FE-01](./items/FE-01.md)** Provenance, the derived spec, and the canonical inventory
@@ -86,7 +90,7 @@ _Nothing marked ready._
     - ● **[EP-05](./items/EP-05.md)** Disposition of the adoption evidence _(1/1)_
       - ● **[FE-12](./items/FE-12.md)** The v1.1 evidence disposition _(1/1)_
         - ● **[ST-13](./items/ST-13.md)** Dispose of the adoption evidence and retire first-unproved-bridge
-  - ◑ **[IN-03](./items/IN-03.md)** Fix what the field trials falsified _(19/28)_
+  - ◑ **[IN-03](./items/IN-03.md)** Fix what the field trials falsified _(19/29)_
     - ● **[EP-06](./items/EP-06.md)** Tier 1 — false invariant blocks _(8/8)_
       - ● **[FE-13](./items/FE-13.md)** The Tier 1 falsifier, written before any mechanism _(3/3)_
         - ● **[ST-14](./items/ST-14.md)** Pin the ceiling: evidence strength constrains the verdict
@@ -99,11 +103,13 @@ _Nothing marked ready._
         - ● **[ST-19](./items/ST-19.md)** The evidence ceiling, and cappedFrom where it fires
         - ● **[ST-20](./items/ST-20.md)** §0i — the defaulting obligation parse
       - ● **[FE-16](./items/FE-16.md)** Land Tier 1 and the §0a fix on main
-    - ● **[EP-07](./items/EP-07.md)** Tier 2 — false assurance _(4/4)_
+    - ◑ **[EP-07](./items/EP-07.md)** Tier 2 — false assurance _(4/5)_
       - ● **[FE-17](./items/FE-17.md)** §0 — a detector with no subject must not report a pass
       - ● **[FE-18](./items/FE-18.md)** §0e — attestations must not be silently permanently fresh
       - ● **[FE-19](./items/FE-19.md)** §0h — a result must say whose property it is about
       - ● **[FE-20](./items/FE-20.md)** §0m — a rule that accepts a pointer must be able to follow it
+      - ◕ **[FE-41](./items/FE-41.md)** NOT_EVALUATED must never carry a numeric compliance score _(0/1)_
+        - ◕ **[ST-25](./items/ST-25.md)** Null the score on NOT_EVALUATED, and pin both routes to it
     - ◑ **[EP-08](./items/EP-08.md)** Tier 3 — semantic inconsistency and representation _(3/10)_
       - ● **[FE-21](./items/FE-21.md)** §0c — a recognized representation of the evidence must not be read as its absence
       - ● **[FE-22](./items/FE-22.md)** §0d — evidence types must mean the same thing to every rule

--- a/artifacts/backlog/items/EP-07.md
+++ b/artifacts/backlog/items/EP-07.md
@@ -3,9 +3,8 @@ id: EP-07
 type: epic
 title: "Tier 2 — false assurance"
 parent: IN-03
-status: COMPLETE
+status: IN_PROGRESS
 opened: 2026-08-10
-closed: 2026-08-12
 evidence:
   - 29dde68
   - 3bc38fa
@@ -35,3 +34,5 @@ One consequence that looks like a regression and is its opposite: this repositor
 Completed to IN_REVIEW in c03aa28, which closed the one incomplete acceptance surface (§0e on `status`) and added the release record the branch lacked. Branch gate green — inventory 22/22, fidelity 33/0, policy valid, diagrams 0 stale, 173 tests, audit exit 0, validate COMPLIANT — and both frozen specimens reproduced unmoved at RH `BLOCKED_BY_INVARIANT` / 88 and PvsNP `NON_COMPLIANT` / 97. Unmerged, and awaiting a landing decision that is not implied by the branch being green.
 
 §0e sits here rather than with the authoring defects: a formatting burden is a cost, but an assurance that silently stops being true is a defect of the same kind as Tier 1, one step further from the verdict.
+
+**Reopened 2026-08-16 for FE-41, and the chronology matters.** This epic was closed correctly on 2026-08-12: it was complete against the four defects it knew about — §0, §0e, §0h, §0m — every one of which came from the two field trials. FE-41 could not have been on that list. It lives in the JSON envelope, a surface no field trial read, and it was found from outside this repository by StandardsEnforcer integrating the pack as a machine consumer. So the closure was not premature and is not being corrected; a newly discovered false-assurance defect is being filed where it belongs by kind. The 1.2.0 release and its evidence stand unchanged, and FE-41 carries its own release boundary.

--- a/artifacts/backlog/items/FE-41.md
+++ b/artifacts/backlog/items/FE-41.md
@@ -1,0 +1,42 @@
+---
+id: FE-41
+type: feature
+title: "NOT_EVALUATED must never carry a numeric compliance score"
+parent: EP-07
+status: IN_REVIEW
+opened: 2026-08-16
+---
+
+## What
+
+Stop the JSON envelope publishing a compliance score on a run that reached no verdict, and report why no score exists rather than emitting a bare `null`.
+
+- `score: null` whenever the status is `NOT_EVALUATED`.
+- `scoreBasis.unavailable: { reason, note }` carrying a closed token — `not-evaluated` or `no-scorable-rules` — and `null` whenever a score is present.
+- Both routes to `NOT_EVALUATED` covered: an absent policy and an unreadable one.
+- No other verdict, denominator or score calculation changes.
+
+## Why
+
+Found from outside this repository, by StandardsEnforcer integrating this pack. Its `describe()` printed the pack's score beside the verdict until MathematicsStandards reported `score: 97` with 52 rules passed *beside a status of `NOT_EVALUATED`*; the consumer's repair was to print less. Reproduced against v2.0.0 on a fixture pair differing only in whether `project-policy.yml` parses:
+
+| fixture | status | score | passed | scored |
+|---|---|---|---|---|
+| `not-evaluated-absent-policy` | `NOT_EVALUATED` | **50** | 4 | 2 |
+| `not-evaluated-unreadable-policy` | `NOT_EVALUATED` | **80** | 7 | 5 |
+
+The number rose as the configuration got worse. With the policy unreadable, fewer required project-subject rules resolved into the denominator and the surviving passes dominated what was left, so a consumer ranking repositories by score placed the broken policy above the absent one. This is not hypothetical outside the fixtures either: the archived `artifacts/adoption/rh-baseline-validate.json` — RiemannHypothesis before it adopted anything — reads `NOT_EVALUATED` with `score: 95`.
+
+The human renderer never had the defect. It returns on both `NOT_EVALUATED` paths before printing a Score line, so this is the machine surface being brought to the semantics the terminal surface already had.
+
+## Notes
+
+**Chronology, so this is not read as EP-07 having been incomplete.** Tier 2 closed correctly on 2026-08-12 against the four defects it knew about — §0, §0e, §0h, §0m — all of which came from the two field trials. This one could not have been on that list: it lives in a surface no field trial read, and it took a machine consumer of the envelope to find it. EP-07 returns to `IN_PROGRESS` because a newly discovered false-assurance defect belongs to it by kind, not because the earlier milestone was wrong.
+
+**Release-bearing.** The envelope's shape changes, so this does not go onto `main` as a silent patch of v2.0.0 behaviour. Implemented and measured on `fe-41-not-evaluated-score`; landing and version assignment are a separate decision, as with every prior tier.
+
+**`scoreBasis.version` deliberately stays at 2.** This changes when a score exists, never how one is computed. Bumping it would tell every consumer their historical numbers are incomparable, which would not be true.
+
+**Both null-reasons are reported, not just the new one.** `score: null` alone cannot distinguish "no verdict was reached" from "the denominator was empty", and the second is a legitimate state of a fully COMPLIANT run — this repository's own was exactly that at 1.2.0. A consumer finding a bare null would guess, and the natural guess ("nothing passed") is wrong in both cases.
+
+**Not adopted alongside it:** `standards-adapter.json` stays at schemaVersion `1.0.0`. The enforcer's new `{policy}` placeholder was forced by a pack that resolves an absent `--policy` to its own; `test/adapter-contract.test.mjs` already proves this pack reads the target's. Declaring 1.1.0 would narrow compatibility with older enforcers for nothing.

--- a/artifacts/backlog/items/FE-41.md
+++ b/artifacts/backlog/items/FE-41.md
@@ -40,3 +40,9 @@ The human renderer never had the defect. It returns on both `NOT_EVALUATED` path
 **Both null-reasons are reported, not just the new one.** `score: null` alone cannot distinguish "no verdict was reached" from "the denominator was empty", and the second is a legitimate state of a fully COMPLIANT run — this repository's own was exactly that at 1.2.0. A consumer finding a bare null would guess, and the natural guess ("nothing passed") is wrong in both cases.
 
 **Not adopted alongside it:** `standards-adapter.json` stays at schemaVersion `1.0.0`. The enforcer's new `{policy}` placeholder was forced by a pack that resolves an absent `--policy` to its own; `test/adapter-contract.test.mjs` already proves this pack reads the target's. Declaring 1.1.0 would narrow compatibility with older enforcers for nothing.
+
+## Release-candidate status
+
+Independently verified at `ca0a54a5aad31124e21562e265e5d03995d2d886` on 2026-08-19 — both reproductions rebuilt from scratch, one control per scored verdict family compared field by field against `main`, the mutation check re-run and restored, the full gate green, and local Docker CI `PASS` on that exact SHA. Measurements in [ST-25](ST-25.md).
+
+Held at `IN_REVIEW`. Landing and version assignment remain a separate decision; nothing here assigns one.

--- a/artifacts/backlog/items/ST-25.md
+++ b/artifacts/backlog/items/ST-25.md
@@ -1,0 +1,33 @@
+---
+id: ST-25
+type: story
+title: "Null the score on NOT_EVALUATED, and pin both routes to it"
+parent: FE-41
+status: IN_REVIEW
+opened: 2026-08-16
+---
+
+## What
+
+The change in `scripts/compliance.mjs`, the fixture pair, and the regression suite.
+
+- `evaluate()` derives `scoreUnavailable` after the status is settled, and `score` is the arithmetic result only when it is `null`.
+- `envelope()` carries it as `scoreBasis.unavailable`.
+- Fixtures `not-evaluated-absent-policy` and `not-evaluated-unreadable-policy`, byte-identical apart from the policy file.
+- `test/not-evaluated-score.test.mjs` — 11 assertions across non-vacuity, both routes, the ranking regression, surface agreement, and containment.
+
+## Why
+
+The regression assertion is the point of the pair: stated as *neither half has a score*, not as *the scores are equal*, because equality would also be satisfied by two numbers that happened to coincide and the property is the absence.
+
+## Notes
+
+**Mutation-checked.** With `scripts/compliance.mjs` reverted to `main`, 7 of the 11 tests go red, including the ranking regression. The 4 that stay green are the two non-vacuity assertions, the basis-identity assertion, and A4 — A4 stays green because the human renderer was always correct, which is exactly what it claims.
+
+**Containment, measured rather than asserted.** RiemannHypothesis validated on this branch and on `main` produces envelopes that are identical apart from the new `scoreBasis.unavailable: null` field, at `BLOCKED_BY_INVARIANT` / 92 both times.
+
+**One live instance found while measuring.** The `F:/Repos/PvsNP` checkout on disk has no `project-policy.yml` and would have published `score: 50` under `NOT_EVALUATED`. It is not the specimen that produced the frozen `NON_COMPLIANT` / 97 reading, so this is an instance of the defect and not a regression in that adopter.
+
+**The archived specimens are not rewritten.** `artifacts/adoption/rh-baseline-validate.json` still reads `NOT_EVALUATED` / 95. They are records of what the framework said on a date, and editing them to match today's code would destroy the evidence this item rests on.
+
+Branch gate: inventory 22/22, fidelity clean, policy valid, diagrams 0 stale, 225 tests (from 214), audit exit 0, validate COMPLIANT.

--- a/artifacts/backlog/items/ST-25.md
+++ b/artifacts/backlog/items/ST-25.md
@@ -31,3 +31,33 @@ The regression assertion is the point of the pair: stated as *neither half has a
 **The archived specimens are not rewritten.** `artifacts/adoption/rh-baseline-validate.json` still reads `NOT_EVALUATED` / 95. They are records of what the framework said on a date, and editing them to match today's code would destroy the evidence this item rests on.
 
 Branch gate: inventory 22/22, fidelity clean, policy valid, diagrams 0 stale, 225 tests (from 214), audit exit 0, validate COMPLIANT.
+
+## Independent verification, 2026-08-19
+
+Run against `ca0a54a5aad31124e21562e265e5d03995d2d886` with the working tree clean before and after, and with the before-side read from a detached worktree at `main` (`5afcd00`) rather than by editing this tree.
+
+**Both reproductions rebuilt from scratch** — fresh temp targets, not the committed fixtures — and reproducing the fixtures' shape exactly (2 and 5 scored rules):
+
+| target | main `5afcd00` | branch `ca0a54a` |
+|---|---|---|
+| no `project-policy.yml` | `NOT_EVALUATED` / **50** | `NOT_EVALUATED` / `null` / `not-evaluated` / exit 2 |
+| unreadable `project-policy.yml` | `NOT_EVALUATED` / **80** | `NOT_EVALUATED` / `null` / `not-evaluated` / exit 2 |
+
+The envelope was walked recursively for any numeric value under a score-named key. The only one is `denominator.scored` — a count of rules in the denominator, not a compliance score. The human renderer emits no `Score:` line and no percentage at all on either path.
+
+**Controls, one per scored verdict family**, each compared field by field against the same target evaluated by `main`:
+
+| family | target | main | branch |
+|---|---|---|---|
+| `COMPLIANT` | `math-compliant` | 100 | 100 |
+| `NON_COMPLIANT` | `escape-hatch-undeclared` | 97 | 97 |
+| `BLOCKED_BY_INVARIANT` | `sorry-certified` | 93 | 93 |
+| `BLOCKED_BY_INVARIANT` | RiemannHypothesis (preserved adopter) | 92 | 92 |
+
+For all four: `results`, `denominator`, `summary`, `assurance`, `blockedBy` and `foreignFailures` are byte-identical to `main`, `scoreBasis.version` is 2 on both sides, and stripping `scoreBasis.unavailable` from the branch envelope makes the whole document equal to `main`'s. The delta is exactly the additive field.
+
+**Mutation re-run.** `scripts/compliance.mjs` restored from `main`: 7 of 11 red, for the preserved reasons — 50 and 80 reappearing where `null` is required, `typeof score` reverting to `number`, and `scoreBasis.unavailable` reverting to `undefined` on a scored control. The 4 that stayed green are the two non-vacuity assertions, the basis-identity assertion, and A4, which is green because the human renderer was always correct. Restored immediately; `git diff`, `git diff --cached` and `git status --porcelain` all clean.
+
+**Gate**, on that SHA: inventory, fidelity, policy, diagrams, assurance-report, tests (225), audit exit 0, validate `COMPLIANT`. `npm run assurance` regenerates the report with no content change (`git diff --quiet` exit 0), so the committed report is current.
+
+**Local Docker CI on the exact SHA: `Result: PASS`**, all eight authoritative stages, environment `docker`, evidence in `artifacts/local-ci/latest.json`.

--- a/scripts/compliance.mjs
+++ b/scripts/compliance.mjs
@@ -552,7 +552,7 @@ function summarise(results, policy) {
   const scoredIds = new Set(scored.map((r) => r.ruleId));
   for (const r of results) r.scored = scoredIds.has(r.ruleId);
   const scoredPassed = scored.filter((r) => r.status === RESULT.passed).length;
-  const score = scored.length === 0 ? null : Math.round((scoredPassed / scored.length) * 100);
+  const rawScore = scored.length === 0 ? null : Math.round((scoredPassed / scored.length) * 100);
 
   const notEvaluated = { noDetector: 0, noSubject: 0, unresolvedRequired: 0, staleAttestation: 0, expiredAttestation: 0 };
   const BUCKET = {
@@ -604,9 +604,53 @@ function summarise(results, policy) {
   else if (excepted.length > 0) status = STATUS.COMPLIANT_WITH_EXCEPTIONS;
   else status = STATUS.COMPLIANT;
 
+  /**
+   * A verdict that was never reached does not carry a number.
+   *
+   * `NOT_EVALUATED` means no policy could be read, so nothing decided which rules govern this
+   * project. The detectors still ran — they read the tree, not the policy — and the aggregation
+   * above still produces an arithmetic result from whatever they happened to find. Publishing that
+   * number beside a status meaning "no verdict" is false assurance of exactly the Tier 2 kind, and
+   * it is not merely decorative: measured at 5afcd00 on one target directory,
+   *
+   *     no project-policy.yml          NOT_EVALUATED  score 50
+   *     unreadable project-policy.yml  NOT_EVALUATED  score 80
+   *
+   * The score ROSE as the configuration got worse, because fewer required project-subject rules
+   * resolved and the surviving passes dominated a shrinking denominator. A consumer ranking
+   * repositories by score placed the broken policy above the absent one.
+   *
+   * The human renderer never had this defect: it returns on both NOT_EVALUATED paths before it
+   * prints a Score line. So this is the machine surface being brought to the semantics the terminal
+   * surface already had — not a new policy about scoring.
+   *
+   * The reason is reported rather than the number simply going absent. `score: null` alone is
+   * ambiguous between "no verdict was reached" and "the denominator was empty", and those are
+   * different facts: this repository's own run is legitimately `null` over zero scorable rules while
+   * being fully COMPLIANT.
+   */
+  const scoreUnavailable =
+    status === STATUS.NOT_EVALUATED
+      ? {
+          reason: "not-evaluated",
+          note:
+            "No verdict was reached, so there is no compliance score. The results below are " +
+            "observations from the detectors, not a measurement of this project against a policy.",
+        }
+      : rawScore === null
+        ? {
+            reason: "no-scorable-rules",
+            note:
+              "No required-level rule whose subject is this project was evaluated, so the score " +
+              "has an empty denominator. This is not a low score; it is the absence of one.",
+          }
+        : null;
+  const score = scoreUnavailable === null ? rawScore : null;
+
   return {
     status,
     score,
+    scoreUnavailable,
     summary: counts,
     assurance,
     denominator: {
@@ -673,6 +717,15 @@ export function envelope({ verdict, project, standardVersion, auditedAt, repo, f
       id: "project-subject-required",
       version: 2,
       since: "1.2.0",
+      /**
+       * Null whenever `score` is a number, and a `{ reason, note }` pair whenever it is not.
+       *
+       * A consumer that finds `score: null` and no reason has to guess which of two unrelated
+       * situations it is in, and the guess that reads more naturally — "nothing passed" — is the
+       * wrong one in both. `reason` is the machine-readable token to branch on; `note` is for a
+       * human reading the JSON. The tokens are closed: `not-evaluated`, `no-scorable-rules`.
+       */
+      unavailable: verdict.scoreUnavailable ?? null,
       note:
         "Version 2 scores required-level rules whose subject is this project, and counts a rule " +
         "whose required evidence could not be read as an unearnable denominator entry. Version 1 " +

--- a/test/fixtures/not-evaluated-absent-policy/README.md
+++ b/test/fixtures/not-evaluated-absent-policy/README.md
@@ -1,12 +1,13 @@
-# A repository that has not adopted these standards
+# A repository that has not usefully adopted these standards
 
-The BEFORE half of the not-evaluated pair. It has no `project-policy.yml`, so nothing has decided
-which rules govern it and `validate` reaches `NOT_EVALUATED`.
-
-Its twin `not-evaluated-unreadable-policy` is byte-identical apart from a `project-policy.yml` that
-does not parse. Both reach the same status by different routes, and the pair exists to pin one
-property:
+One half of the not-evaluated pair. The two halves are byte-identical apart from `project-policy.yml`:
+`not-evaluated-absent-policy` has none, and `not-evaluated-unreadable-policy` has one that does not
+parse. Both reach `NOT_EVALUATED` by different routes, and the pair exists to pin one property:
 
     a status of NOT_EVALUATED carries no compliance score, so neither half can rank above the other.
 
-Before that property held, the twin with the broken policy scored HIGHER than this one.
+This file is identical in both halves on purpose. If it differed, the halves would differ in what the
+detectors read as well as in the policy, and the comparison would stop isolating the policy.
+
+Before the property held, the half with the broken policy scored 80 and this pairing scored 50 — the
+higher number belonging to the repository that had made its configuration worse.

--- a/test/fixtures/not-evaluated-absent-policy/README.md
+++ b/test/fixtures/not-evaluated-absent-policy/README.md
@@ -1,0 +1,12 @@
+# A repository that has not adopted these standards
+
+The BEFORE half of the not-evaluated pair. It has no `project-policy.yml`, so nothing has decided
+which rules govern it and `validate` reaches `NOT_EVALUATED`.
+
+Its twin `not-evaluated-unreadable-policy` is byte-identical apart from a `project-policy.yml` that
+does not parse. Both reach the same status by different routes, and the pair exists to pin one
+property:
+
+    a status of NOT_EVALUATED carries no compliance score, so neither half can rank above the other.
+
+Before that property held, the twin with the broken policy scored HIGHER than this one.

--- a/test/fixtures/not-evaluated-unreadable-policy/README.md
+++ b/test/fixtures/not-evaluated-unreadable-policy/README.md
@@ -1,12 +1,13 @@
-# A repository that has not adopted these standards
+# A repository that has not usefully adopted these standards
 
-The BEFORE half of the not-evaluated pair. It has no `project-policy.yml`, so nothing has decided
-which rules govern it and `validate` reaches `NOT_EVALUATED`.
-
-Its twin `not-evaluated-unreadable-policy` is byte-identical apart from a `project-policy.yml` that
-does not parse. Both reach the same status by different routes, and the pair exists to pin one
-property:
+One half of the not-evaluated pair. The two halves are byte-identical apart from `project-policy.yml`:
+`not-evaluated-absent-policy` has none, and `not-evaluated-unreadable-policy` has one that does not
+parse. Both reach `NOT_EVALUATED` by different routes, and the pair exists to pin one property:
 
     a status of NOT_EVALUATED carries no compliance score, so neither half can rank above the other.
 
-Before that property held, the twin with the broken policy scored HIGHER than this one.
+This file is identical in both halves on purpose. If it differed, the halves would differ in what the
+detectors read as well as in the policy, and the comparison would stop isolating the policy.
+
+Before the property held, the half with the broken policy scored 80 and this pairing scored 50 — the
+higher number belonging to the repository that had made its configuration worse.

--- a/test/fixtures/not-evaluated-unreadable-policy/README.md
+++ b/test/fixtures/not-evaluated-unreadable-policy/README.md
@@ -1,0 +1,12 @@
+# A repository that has not adopted these standards
+
+The BEFORE half of the not-evaluated pair. It has no `project-policy.yml`, so nothing has decided
+which rules govern it and `validate` reaches `NOT_EVALUATED`.
+
+Its twin `not-evaluated-unreadable-policy` is byte-identical apart from a `project-policy.yml` that
+does not parse. Both reach the same status by different routes, and the pair exists to pin one
+property:
+
+    a status of NOT_EVALUATED carries no compliance score, so neither half can rank above the other.
+
+Before that property held, the twin with the broken policy scored HIGHER than this one.

--- a/test/fixtures/not-evaluated-unreadable-policy/project-policy.yml
+++ b/test/fixtures/not-evaluated-unreadable-policy/project-policy.yml
@@ -1,0 +1,13 @@
+# The AFTER half of the not-evaluated pair: a policy that cannot be read.
+#
+# The unterminated flow sequence below is a parse error, not a schema error, so the reader refuses
+# the document rather than reporting a field. `validate` reaches NOT_EVALUATED and exits 2 — a
+# configuration error, deliberately not a compliance failure.
+#
+# It must not score. Before FE-41 this half scored HIGHER than `not-evaluated-absent-policy`, whose
+# only difference is that this file is absent there: with the policy unreadable, fewer required
+# project-subject rules resolved into the denominator and the surviving passes dominated what was
+# left. Breaking the configuration improved the number.
+standardVersion: "1.0.0"
+project: "not-evaluated-unreadable-policy"
+exceptions: [

--- a/test/not-evaluated-score.test.mjs
+++ b/test/not-evaluated-score.test.mjs
@@ -1,0 +1,201 @@
+/**
+ * FE-41 · a status of NOT_EVALUATED carries no compliance score.
+ *
+ * WHERE THIS DEFECT CAME FROM. Not from this repository's own review. StandardsEnforcer found it
+ * from the outside, integrating MathematicsStandards as a pack: its `describe()` used to print the
+ * pack's project, score and pass counts beside the verdict, and it stopped because
+ * MathematicsStandards reported `score: 97` with 52 rules passed *beside a status of
+ * `NOT_EVALUATED`*. The consumer worked around it by printing less. Reproduced against v2.0.0 on a
+ * fixture pair identical apart from one file:
+ *
+ *     not-evaluated-absent-policy      NOT_EVALUATED  score 50   (4 passed, 2 scored)
+ *     not-evaluated-unreadable-policy  NOT_EVALUATED  score 80   (7 passed, 5 scored)
+ *
+ * The number ROSE as the configuration got worse. With the policy unreadable, fewer required
+ * project-subject rules resolved into the denominator and the surviving passes dominated what was
+ * left, so a consumer ranking repositories by score placed the broken policy above the absent one.
+ * That is EP-07's false assurance arriving through the surface EP-07 did not check: the human
+ * renderer has always returned on both NOT_EVALUATED paths before printing a Score line, and only
+ * the JSON envelope diverged.
+ *
+ * WHAT IS PINNED HERE. That the two surfaces now agree, that both routes to NOT_EVALUATED are
+ * covered rather than the one that was reported, and that the absence of a score is reported with a
+ * reason rather than as a bare null — `score: null` alone cannot distinguish "no verdict was
+ * reached" from "the denominator was empty", and the second is a legitimate state of a fully
+ * COMPLIANT run.
+ *
+ * Every assertion names a status, a token or a named denominator part — never a bare aggregate.
+ * design/testing-principles.md §4.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { loadCatalog } from "../scripts/catalog.mjs";
+import { evaluate, STATUS } from "../scripts/compliance.mjs";
+import { HOME, run } from "./helpers/cli.mjs";
+
+const catalog = await loadCatalog(path.join(HOME, "rules"));
+const fixture = (name) => path.join(HOME, "test/fixtures", name);
+
+function validate(name, extra = []) {
+  const { code, out } = run(["validate", `--dir=${fixture(name)}`, ...extra]);
+  return { code, out };
+}
+
+function envelopeFor(name) {
+  const { out } = validate(name, ["--json"]);
+  try {
+    return JSON.parse(out);
+  } catch {
+    assert.fail(`no JSON envelope from ${name}: ${out.slice(0, 400)}`);
+  }
+}
+
+/** The two routes to NOT_EVALUATED. Both must be covered; only the first was ever reported. */
+const ABSENT = "not-evaluated-absent-policy";
+const UNREADABLE = "not-evaluated-unreadable-policy";
+
+// ---------------------------------------------------------------------------
+// A1 · non-vacuity. The pair must actually reach NOT_EVALUATED, by two routes.
+//
+// Without this, every assertion below could hold because the fixtures quietly stopped being
+// NOT_EVALUATED at all, and the file would pin nothing.
+// ---------------------------------------------------------------------------
+
+test("A1 · both halves of the pair reach NOT_EVALUATED, and exit 2", () => {
+  for (const name of [ABSENT, UNREADABLE]) {
+    const envelope = envelopeFor(name);
+    assert.equal(envelope.status, STATUS.NOT_EVALUATED, `${name} no longer reaches NOT_EVALUATED`);
+    assert.equal(
+      validate(name).code,
+      2,
+      `${name} must exit 2: an unusable policy is a configuration error, not a compliance failure`,
+    );
+  }
+});
+
+test("A1 · they differ in the one way the pair exists to isolate", () => {
+  // The unreadable half resolves more rules than the absent half — that difference is the engine
+  // of the old defect, and it is deliberately NOT removed by this fix. What changes is that the
+  // difference can no longer reach a published number.
+  assert.notEqual(
+    envelopeFor(ABSENT).denominator.scored,
+    envelopeFor(UNREADABLE).denominator.scored,
+    "the pair no longer differs in what resolves; the ranking regression below would hold trivially",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// A2 · the score itself.
+// ---------------------------------------------------------------------------
+
+test("A2 · an absent policy yields no score, with the reason", () => {
+  const envelope = envelopeFor(ABSENT);
+  assert.equal(envelope.score, null, "measured 50 before this fix");
+  assert.equal(envelope.scoreBasis.unavailable.reason, "not-evaluated");
+  assert.match(envelope.scoreBasis.unavailable.note, /no verdict was reached/i);
+});
+
+test("A2 · an unreadable policy yields no score, with the same reason", () => {
+  const envelope = envelopeFor(UNREADABLE);
+  assert.equal(envelope.score, null, "measured 80 before this fix");
+  assert.equal(envelope.scoreBasis.unavailable.reason, "not-evaluated");
+});
+
+test("A2 · the reason is a token to branch on, not only prose", () => {
+  // A consumer must not have to regex the note. The vocabulary is closed at two.
+  const unavailable = envelopeFor(ABSENT).scoreBasis.unavailable;
+  assert.deepEqual(Object.keys(unavailable).sort(), ["note", "reason"]);
+  assert.ok(["not-evaluated", "no-scorable-rules"].includes(unavailable.reason));
+});
+
+// ---------------------------------------------------------------------------
+// A3 · THE REGRESSION. The malformed half cannot rank above the absent half.
+//
+// Stated as "neither has a score", not as "the scores are equal". Equality would also be satisfied
+// by two numbers that happened to coincide, and the property is the absence, not the tie.
+// ---------------------------------------------------------------------------
+
+test("A3 · breaking the policy cannot produce a better number, because there is no number", () => {
+  const absent = envelopeFor(ABSENT);
+  const unreadable = envelopeFor(UNREADABLE);
+
+  assert.equal(typeof absent.score, "object", `score must be null, got ${absent.score}`);
+  assert.equal(typeof unreadable.score, "object", `score must be null, got ${unreadable.score}`);
+  assert.equal(absent.score, null);
+  assert.equal(unreadable.score, null);
+
+  // The old comparison, written out so a future reader can see what it was: 80 > 50, from the
+  // repository that had made its configuration worse.
+  assert.ok(
+    !(unreadable.score > absent.score),
+    "a repository improved its published score by breaking its policy file",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// A4 · the two surfaces agree.
+//
+// The human renderer was already correct. This asserts the fix closed the gap rather than moving
+// it: if a future change starts printing a Score line on these paths, the JSON is no longer the
+// only surface that could be wrong.
+// ---------------------------------------------------------------------------
+
+test("A4 · the human render carries no score on either NOT_EVALUATED path", () => {
+  for (const name of [ABSENT, UNREADABLE]) {
+    const { out } = validate(name);
+    assert.match(out, /NOT_EVALUATED/, `${name} must say so in the human output`);
+    assert.doesNotMatch(out, /^\s*Score:/m, `${name} printed a score beside a status meaning none`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// A5 · nothing else moved. Scoring is unchanged wherever a verdict was reached.
+// ---------------------------------------------------------------------------
+
+test("A5 · verdicts that were reached keep their scores, and declare no unavailability", () => {
+  // One of each shape: compliant, non-compliant, blocked. Numbers are the v2.0.0 values.
+  for (const [name, status, score] of [
+    ["math-compliant", "COMPLIANT", 100],
+    ["escape-hatch-undeclared", "NON_COMPLIANT", 97],
+    ["sorry-certified", "BLOCKED_BY_INVARIANT", 93],
+  ]) {
+    const envelope = envelopeFor(name);
+    assert.equal(envelope.status, status, name);
+    assert.equal(envelope.score, score, `${name}'s score moved; this change was not meant to touch it`);
+    assert.equal(envelope.scoreBasis.unavailable, null, `${name} has a score and must claim none is missing`);
+  }
+});
+
+test("A5 · the basis identity is untouched, so scores stay comparable across this change", () => {
+  // FE-41 changes when a score exists, never how one is computed. A bumped version here would tell
+  // every consumer their historical numbers are incomparable, which would not be true.
+  const basis = envelopeFor("escape-hatch-undeclared").scoreBasis;
+  assert.equal(basis.id, "project-subject-required");
+  assert.equal(basis.version, 2);
+  assert.equal(basis.since, "1.2.0");
+});
+
+// ---------------------------------------------------------------------------
+// A6 · the second token, at the verdict boundary.
+//
+// `no-scorable-rules` is the pre-existing null: a run that reached a verdict over an empty
+// denominator. No fixture produces it — every one of them scores something — so it is asserted
+// where it is reachable without inventing a repository, and it matters because it is the case
+// `not-evaluated` must not be confused with.
+// ---------------------------------------------------------------------------
+
+test("A6 · an empty denominator is distinguished from an unreached verdict", () => {
+  const verdict = evaluate({ catalog, policy: { standardVersion: "1.0.0", project: "t" }, findings: [], evaluated: [], today: "2026-08-16" });
+  assert.equal(verdict.status, STATUS.COMPLIANT, "a verdict WAS reached here");
+  assert.equal(verdict.score, null);
+  assert.equal(verdict.scoreUnavailable.reason, "no-scorable-rules");
+});
+
+test("A6 · no policy is the other one, at the same boundary", () => {
+  const verdict = evaluate({ catalog, policy: null, findings: [], evaluated: [], today: "2026-08-16" });
+  assert.equal(verdict.status, STATUS.NOT_EVALUATED);
+  assert.equal(verdict.score, null);
+  assert.equal(verdict.scoreUnavailable.reason, "not-evaluated");
+});


### PR DESCRIPTION
`NOT_EVALUATED` must never carry a numeric compliance score.

Found from outside this repository, by StandardsEnforcer integrating this pack as a machine
consumer. Its `describe()` printed the pack's score beside the verdict until MathematicsStandards
reported `score: 97` with 52 rules passed *beside a status of `NOT_EVALUATED`*; the consumer's
repair was to print less. Reproduced against v2.0.0 on a fixture pair differing only in whether
`project-policy.yml` parses:

| fixture | status | score | passed | scored |
|---|---|---|---|---|
| `not-evaluated-absent-policy` | `NOT_EVALUATED` | **50** | 4 | 2 |
| `not-evaluated-unreadable-policy` | `NOT_EVALUATED` | **80** | 7 | 5 |

The number rose as the configuration got worse: with the policy unreadable, fewer required
project-subject rules resolved into the denominator and the surviving passes dominated what was
left, so a consumer ranking repositories by score placed the broken policy above the absent one.
The archived `artifacts/adoption/rh-baseline-validate.json` — RiemannHypothesis before it adopted
anything — reads `NOT_EVALUATED` with `score: 95`.

The human renderer never had the defect; it returns on both `NOT_EVALUATED` paths before printing
a Score line. This is the machine surface being brought to the semantics the terminal surface
already had, not a new policy about scoring.

**What changes.** `score: null` whenever the status is `NOT_EVALUATED`, and
`scoreBasis.unavailable: { reason, note }` carrying a closed token — `not-evaluated` or
`no-scorable-rules` — and `null` whenever a score is present. Both reasons are reported because a
bare `null` cannot distinguish "no verdict was reached" from "the denominator was empty", and the
second is a legitimate state of a fully COMPLIANT run: this repository's own, at 1.2.0.

**What does not change.** `scoreBasis.version` stays at `2`. This changes when a score exists,
never how one is computed; bumping it would tell every consumer their historical numbers are
incomparable, which would not be true. No other verdict, denominator, rule result or finding
moves. `standards-adapter.json` stays at schemaVersion `1.0.0`.

**Independently verified at `ca0a54a`**, with both reproductions rebuilt from scratch, one control
per scored verdict family compared field by field against `main` from a detached worktree, the
mutation check re-run and restored, and the whole gate green. `COMPLIANT`/100,
`NON_COMPLIANT`/97, `BLOCKED_BY_INVARIANT`/93 and RiemannHypothesis/92 are unchanged, and
stripping `scoreBasis.unavailable` from a branch envelope makes it byte-equal to `main`'s. The
delta is exactly the additive field. Measurements in `artifacts/backlog/items/ST-25.md`.

**This is release-bearing and this PR does not assign a version.** The envelope's shape changes,
so it must not reach `main` as a silent patch of v2.0.0 behaviour. Landing it can legitimately
leave FE-41 `IN_REVIEW` and EP-07 `IN_PROGRESS` until the release boundary is decided separately.

**Why it is being submitted now, ahead of unrelated work.** Two follow-on items depend on it:
FE-42 is parented to EP-07, which this branch reopens, and the EP-12 container-tree work was
branched above it. An earlier PR carried the hygiene commit on top of this candidate and was
closed rather than merged, because its diff included this change while its description said it did
not. Nothing here has been rebased or rewritten.

---

## Local CI

Verified by the repository's containerized pipeline on the submitting developer's machine.
This is **not** a GitHub Actions result; GitHub-hosted CI may or may not have run.

- **Verified commit:** `85b27b7f2715ad8595bec8b3db82211dfded5c97`
- **Branch:** `fe-41-not-evaluated-score`
- **Result:** PASS
- **Environment:** Docker (`compose.ci.yml`, no network, disposable)
- **Stages:** inventory, fidelity, policy, diagrams, assurance-report, tests, audit, validate
- **Completed:** 2026-08-23T19:45:45.279Z

The commit pushed for this PR is exactly the commit that passed that pipeline:
`scripts/submit-pr.mjs` resolves HEAD before and after the run, refuses to continue if it
moved, and pushes the verified SHA by name. Reproduce with:

```
node scripts/ci.mjs --commit=85b27b7f2715ad8595bec8b3db82211dfded5c97
```
