### PR TITLE
Backlog: state IN-04's hosted-CI position as a capability, not a moment

### DIFF
--- a/artifacts/backlog/items/IN-04.md
+++ b/artifacts/backlog/items/IN-04.md
@@ -23,7 +23,11 @@ Distinct from IN-03 on purpose. IN-03 fixes what the field trials falsified in t
 
 Left IN_PROGRESS. EP-11 closed what was asked for; the remainder is what this initiative still holds.
 
-**The hosted workflow can now execute, and that half is closed.** It was recorded here on 2026-08-16 as an open blocker, and it stopped being one the same day: the account billing check that had failed every run was repaired, and runs `31963761001` and `31963743124` both executed all eight stages green. The earlier red marks are non-starts, not defects. Nothing about this changes the standing of local Docker CI, which remains the gate `scripts/submit-pr.mjs` enforces, for the reason EP-11 gives.
+**The hosted workflow is demonstrated, non-authoritative, and intermittently unavailable.** It has executed the full pipeline on neutral hardware more than once — runs `31963761001` and `31963743124` on 2026-08-16, and run `32877711524` attempt 3 on 2026-08-26, which carried all eight stages and 250/250 tests green on the v3.0.0 release artifact `1faedcd`. So the capability is real and that half of the original blocker is closed.
+
+It is **not** a gate, and its availability is not guaranteed. Hosted runs stop starting whenever the account's billing or spending limit lapses, and that condition has recurred repeatedly — including twice on 2026-08-26, once on either side of the release, the second time 23 minutes after a successful run. A non-start is recognisable and must not be read as a failure: zero steps, `runner_id` 0, no retrievable log, and the reason available only from the check-run annotation.
+
+The durable position, unchanged by any of it: **local Docker CI is the required gate**, enforced on the exact SHA by `scripts/submit-pr.mjs` for the reason EP-11 gives. Hosted Actions is an independent second witness — preserved as evidence when it runs, investigated when it genuinely fails, and recorded but not waited on when it never starts.
 
 **`artifacts/backlog/README.md:3` still tells the reader to "re-run the backlog script after changing anything in items/", and this repository contains no such script** — no `scripts/backlog.mjs`, no npm script matching it. Re-verified 2026-08-23. The tracker is generated, and generated correctly, but by a user-level skill that lives outside the repository; a contributor without that skill installed is told to run something that does not exist. Still unowned.
 


### PR DESCRIPTION
## Local CI

Verified by the repository's containerized pipeline on the submitting developer's machine.
This is **not** a GitHub Actions result; GitHub-hosted CI may or may not have run.

- **Verified commit:** `8c2d0496823817a31153371b7b19c7598c4e7a5c`
- **Branch:** `in-04-hosted-ci-note`
- **Result:** PASS
- **Environment:** Docker (`compose.ci.yml`, no network, disposable)
- **Stages:** inventory, fidelity, policy, diagrams, assurance-report, tests, audit, validate, mutation-check
- **Completed:** 2026-08-26T23:32:33.110Z

The commit pushed for this PR is exactly the commit that passed that pipeline:
`scripts/submit-pr.mjs` resolves HEAD before and after the run, refuses to continue if it
moved, and pushes the verified SHA by name. Reproduce with:

```
node scripts/ci.mjs --commit=8c2d0496823817a31153371b7b19c7598c4e7a5c
```
